### PR TITLE
fix: .screenplay container should use `overflow: auto` instead of `scroll`

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -66,7 +66,7 @@
 .screenplay:not(.is-phone) {
 	width: var(--max-width);
 	min-width: var(--max-width);
-	overflow: scroll;
+	overflow: auto;
 }
 
 .is-phone .screenplay {


### PR DESCRIPTION
Bug Screenshot

<img width="1440" height="900" alt="2e3b6b24e6ac31d58fd9358890fe604d0ef070d5dc65f97f854903fe169fad61" src="https://github.com/user-attachments/assets/eb8d822f-b4bf-49cd-9b8a-03631b1e0dca" />
